### PR TITLE
Clarify test usage and enable CTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(MyCTestProject C CXX)
 
 # Enable testing
 enable_testing()
+include(CTest)
 
 # Set C standard
 set(CMAKE_C_STANDARD 11)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,25 @@ Game Boy Emulation in C (gcc9). For self study - NOT INDUSTRIAL GRADE MATERIAL
 * tests ... testcode
 * doc ... documents
 
+## Building and Running Tests
+
+1. Configure and build the project:
+
+   ```bash
+   cmake -S . -B build
+   cmake --build build
+   ```
+
+2. Execute the test suite from the build directory:
+
+   ```bash
+   cd build && ctest --output-on-failure
+   ```
+
+Using `ctest -T test` requires `DartConfiguration.tcl`, which is generated when
+`include(CTest)` is present in the `CMakeLists.txt`. Running `ctest` as shown
+above is sufficient for local testing.
+
 ## Todos
 
 * [x] Check overview of GB


### PR DESCRIPTION
## Summary
- enable basic CTest setup in `CMakeLists.txt`
- update `README` with instructions for building and running tests

## Testing
- `cmake -S . -B build && cmake --build build --target tests` *(fails: cannot download googletest)*

------
https://chatgpt.com/codex/tasks/task_e_684934d0232083258cc4b432f6f26c65