### PR TITLE
Fix VSCode debugger path

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,10 +2,23 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Run main_exec",
+            "name": "Run boyc_exec",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${workspaceFolder}/build/main_exec",
+            "program": "${workspaceFolder}/build/boyc_exec",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "miDebuggerPath": "/usr/bin/gdb"
+        },
+        {
+            "name": "Run unit tests",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/tests",
             "args": [],
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,


### PR DESCRIPTION
## Summary
- fix `launch.json` to point to built executable `boyc_exec`
- add configuration to debug unit test binary

## Testing
- `cmake .. && cmake --build . && ctest --output-on-failure` *(fails: download googletest)*

------
https://chatgpt.com/codex/tasks/task_e_684aa53640e08325a01e268abcbf1241