### PR TITLE
Fix test ROM path with C string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,12 +37,17 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
 # Add test executable
-add_executable(tests 
+add_executable(tests
   tests/cpu/cpu-test.cpp
   src/cpu/cpu.cpp
   src/cpu/cpu_ops.cpp
   src/mem/mem.cpp
   src/rom/rom.cpp)
+
+# Provide the absolute path to the bundled test ROMs so unit tests can
+# locate them when executed from the build directory.
+target_compile_definitions(tests PRIVATE
+  TEST_ROM_DIR="${CMAKE_SOURCE_DIR}/tests/test_roms/bin")
   
 target_link_libraries(tests gtest_main)
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ Game Boy Emulation in C (gcc9). For self study - NOT INDUSTRIAL GRADE MATERIAL
    cd build && ctest --output-on-failure
    ```
 
+   The unit tests rely on ROM images provided via a git submodule. If you have
+   just cloned the repository, fetch these files first:
+
+   ```bash
+   git submodule update --init --recursive
+   ```
+
 Using `ctest -T test` requires `DartConfiguration.tcl`, which is generated when
 `include(CTest)` is present in the `CMakeLists.txt`. Running `ctest` as shown
 above is sufficient for local testing.

--- a/tests/cpu/cpu-test.cpp
+++ b/tests/cpu/cpu-test.cpp
@@ -2,6 +2,7 @@
 #include "cpu.h"
 #include "mem.h"
 #include "rom.h"
+#include <stdio.h>
 
 #define ROM_SIZE 0x8000 // 32KB
 
@@ -32,7 +33,9 @@ TEST(cpu_step_one_step_success, cpu_step) {
 
     uint8_t rom_image[ROM_SIZE]; 
 
-    ret = load_rom("./tests/test_roms/bin/cpu_bus_1.gb", rom_image, ROM_SIZE);
+    char rom_path[256];
+    snprintf(rom_path, sizeof(rom_path), "%s/cpu_bus_1.gb", TEST_ROM_DIR);
+    ret = load_rom(rom_path, rom_image, ROM_SIZE);
     EXPECT_EQ(ret, 0);
 
     mem_t *mem = mem_create(rom_image, ROM_SIZE);


### PR DESCRIPTION
## Summary
- update CPU unit test to build ROM file path with `snprintf`
- remove C++ string header

## Testing
- `cmake ..` *(fails: googletest download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684ae240376483259f7a10b66ae9730f