### PR TITLE
Add SDL2 display tests and rename draw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,16 @@
 cmake_minimum_required(VERSION 3.14)
 project(MyCTestProject C CXX)
 
+find_package(SDL2 REQUIRED)
+
 # Configure include paths
 include_directories(
   ${CMAKE_SOURCE_DIR}/src
   ${CMAKE_SOURCE_DIR}/src/cpu
   ${CMAKE_SOURCE_DIR}/src/mem
   ${CMAKE_SOURCE_DIR}/src/rom
+  ${CMAKE_SOURCE_DIR}/src/display
+  ${SDL2_INCLUDE_DIRS}
 )
 
 # Enable testing
@@ -17,11 +21,14 @@ include(CTest)
 set(CMAKE_C_STANDARD 11)
 
 # Add your C source
-add_executable(boyc_exec 
+add_executable(boyc_exec
   src/main.cpp
   src/mem/mem.cpp
   src/cpu/cpu.cpp
-  src/rom/rom.cpp)
+  src/rom/rom.cpp
+  src/display/display.cpp)
+
+target_link_libraries(boyc_exec SDL2::SDL2)
 
 # Download and add GoogleTest
 include(FetchContent)
@@ -38,12 +45,14 @@ FetchContent_MakeAvailable(googletest)
 # Add test executable
 add_executable(tests
   tests/cpu/cpu-test.cpp
+  tests/display/display-test.cpp
   src/cpu/cpu.cpp
   src/mem/mem.cpp
-  src/rom/rom.cpp)
+  src/rom/rom.cpp
+  src/display/display.cpp)
 
   
-  target_link_libraries(tests gtest_main)
+target_link_libraries(tests gtest_main SDL2::SDL2)
   
 # Register the tests
 include(GoogleTest)

--- a/src/display/display.cpp
+++ b/src/display/display.cpp
@@ -1,0 +1,112 @@
+#include "display.h"
+#include <SDL.h>
+#include <stdio.h>
+
+static SDL_Window *window = nullptr;
+static SDL_Renderer *renderer = nullptr;
+static SDL_Texture *texture = nullptr;
+static int disp_width = 0;
+static int disp_height = 0;
+
+int display_init(int width, int height)
+{
+    if (SDL_Init(SDL_INIT_VIDEO) != 0) {
+        fprintf(stderr, "SDL_Init Error: %s\n", SDL_GetError());
+        return -1;
+    }
+
+    window = SDL_CreateWindow("BoyC", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+                              width, height, SDL_WINDOW_SHOWN);
+    if (!window) {
+        fprintf(stderr, "SDL_CreateWindow Error: %s\n", SDL_GetError());
+        SDL_Quit();
+        return -1;
+    }
+
+    renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
+    if (!renderer) {
+        fprintf(stderr, "SDL_CreateRenderer Error: %s\n", SDL_GetError());
+        SDL_DestroyWindow(window);
+        SDL_Quit();
+        return -1;
+    }
+
+    texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_ARGB8888,
+                                SDL_TEXTUREACCESS_STREAMING, width, height);
+    if (!texture) {
+        fprintf(stderr, "SDL_CreateTexture Error: %s\n", SDL_GetError());
+        SDL_DestroyRenderer(renderer);
+        SDL_DestroyWindow(window);
+        SDL_Quit();
+        return -1;
+    }
+
+    disp_width = width;
+    disp_height = height;
+    return 0;
+}
+
+void display_render(const uint32_t *pixels)
+{
+    if (renderer == NULL) {
+        return;
+    }
+    SDL_UpdateTexture(texture, nullptr, pixels, disp_width * sizeof(uint32_t));
+    SDL_RenderClear(renderer);
+    SDL_RenderCopy(renderer, texture, nullptr, nullptr);
+    SDL_RenderPresent(renderer);
+}
+
+void display_draw_line(int x1, int y1, int x2, int y2, uint32_t color)
+{
+    if (renderer == NULL) {
+        return;
+    }
+    SDL_SetRenderDrawColor(renderer,
+                           (color >> 16) & 0xFF,
+                           (color >> 8) & 0xFF,
+                           color & 0xFF,
+                           (color >> 24) & 0xFF);
+    SDL_RenderDrawLine(renderer, x1, y1, x2, y2);
+    SDL_RenderPresent(renderer);
+}
+
+void display_draw_circle(int cx, int cy, int r, uint32_t color)
+{
+    if (renderer == NULL) {
+        return;
+    }
+    SDL_SetRenderDrawColor(renderer,
+                           (color >> 16) & 0xFF,
+                           (color >> 8) & 0xFF,
+                           color & 0xFF,
+                           (color >> 24) & 0xFF);
+    for (int w = 0; w < r * 2; w++) {
+        for (int h = 0; h < r * 2; h++) {
+            int dx = r - w; // horizontal offset
+            int dy = r - h; // vertical offset
+            if ((dx*dx + dy*dy) <= (r * r)) {
+                SDL_RenderDrawPoint(renderer, cx + dx, cy + dy);
+            }
+        }
+    }
+    SDL_RenderPresent(renderer);
+}
+
+void display_destroy()
+{
+    if (texture) {
+        SDL_DestroyTexture(texture);
+        texture = nullptr;
+    }
+    if (renderer) {
+        SDL_DestroyRenderer(renderer);
+        renderer = nullptr;
+    }
+    if (window) {
+        SDL_DestroyWindow(window);
+        window = nullptr;
+    }
+    SDL_Quit();
+}
+

--- a/src/display/display.h
+++ b/src/display/display.h
@@ -1,0 +1,20 @@
+#ifndef DISPLAY_H
+#define DISPLAY_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+int display_init(int width, int height);
+void display_render(const uint32_t *pixels);
+void display_draw_line(int x1, int y1, int x2, int y2, uint32_t color);
+void display_draw_circle(int cx, int cy, int r, uint32_t color);
+void display_destroy();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DISPLAY_H */

--- a/tests/display/display-test.cpp
+++ b/tests/display/display-test.cpp
@@ -1,0 +1,20 @@
+#include <gtest/gtest.h>
+#include "display.h"
+
+TEST(display_line_test, draw_line) {
+    if (display_init(64, 64) != 0) {
+        GTEST_SKIP() << "SDL2 not available";
+    }
+    display_draw_line(0, 0, 63, 63, 0xFFFFFFFF);
+    display_destroy();
+    SUCCEED();
+}
+
+TEST(display_circle_test, draw_circle) {
+    if (display_init(64, 64) != 0) {
+        GTEST_SKIP() << "SDL2 not available";
+    }
+    display_draw_circle(32, 32, 10, 0xFFFFFFFF);
+    display_destroy();
+    SUCCEED();
+}


### PR DESCRIPTION
## Summary
- rename `display_draw` to `display_render`
- implement simple line and circle drawing helpers
- add a new display test suite using GoogleTest
- link SDL2 in the test target
- tweak SDL renderer checks

## Testing
- `cmake -S . -B build` *(fails: could not find SDL2)*
- `cmake --build build` *(fails: no Makefile)*
- `cd build && ctest --output-on-failure` *(no tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_684d54237eac8325becf98fb20437c7a