### PR TITLE
Fix mem initialization and allow build without SDL2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,16 @@
 cmake_minimum_required(VERSION 3.14)
 project(MyCTestProject C CXX)
 
-find_package(SDL2 REQUIRED)
+find_package(SDL2 QUIET)
+if (SDL2_FOUND)
+  message(STATUS "Using SDL2")
+  set(DISPLAY_SRC src/display/display.cpp)
+  set(DISPLAY_LIBS SDL2::SDL2)
+else()
+  message(STATUS "SDL2 not found - using stub display")
+  set(DISPLAY_SRC src/display/display_stub.cpp)
+  set(DISPLAY_LIBS)
+endif()
 
 # Configure include paths
 include_directories(
@@ -26,9 +35,9 @@ add_executable(boyc_exec
   src/mem/mem.cpp
   src/cpu/cpu.cpp
   src/rom/rom.cpp
-  src/display/display.cpp)
+  ${DISPLAY_SRC})
 
-target_link_libraries(boyc_exec SDL2::SDL2)
+target_link_libraries(boyc_exec ${DISPLAY_LIBS})
 
 # Download and add GoogleTest
 include(FetchContent)
@@ -50,12 +59,12 @@ add_executable(tests
   src/cpu/cpu.cpp
   src/mem/mem.cpp
   src/rom/rom.cpp
-  src/display/display.cpp)
+  ${DISPLAY_SRC})
 target_include_directories(tests PRIVATE
   tests/helper)
 
   
-target_link_libraries(tests gtest_main SDL2::SDL2)
+target_link_libraries(tests gtest_main ${DISPLAY_LIBS})
   
 # Register the tests
 include(GoogleTest)

--- a/src/display/display_stub.cpp
+++ b/src/display/display_stub.cpp
@@ -1,0 +1,12 @@
+#include "display.h"
+#include <stdint.h>
+
+int display_init(int width, int height) {
+    (void)width; (void)height; return -1; /* indicate SDL not available */
+}
+void display_render(const uint32_t *pixels) { (void)pixels; }
+void display_draw_line(int x1, int y1, int x2, int y2, uint32_t color) {
+    (void)x1; (void)y1; (void)x2; (void)y2; (void)color; }
+void display_draw_circle(int cx, int cy, int r, uint32_t color) {
+    (void)cx; (void)cy; (void)r; (void)color; }
+void display_destroy() {}

--- a/src/mem/mem.cpp
+++ b/src/mem/mem.cpp
@@ -125,7 +125,10 @@ void mem_write_word(mem_t *m, uint16_t adr, uint16_t value)
    plus call-outs for DMA, joypad latches, timer increments, etc.        */
 
 mem_t *mem_create(const uint8_t *rom_image, size_t rom_size){
-    mem_t *memory = (mem_t *) malloc(sizeof(mem_t));
+    mem_t *memory = (mem_t *) calloc(1, sizeof(mem_t));
+    if (!memory) {
+        return nullptr;
+    }
     memory->rom = rom_image;
     memory->rom_size = rom_size;
 


### PR DESCRIPTION
## Summary
- add stubbed display implementation when SDL2 isn't available
- zero-initialize memory struct in `mem_create`
- adjust CMake to use the stub and avoid linking SDL2 if the library isn't found

## Testing
- `cmake ..` *(fails: could not download googletest)*

------
https://chatgpt.com/codex/tasks/task_e_684d71c948d08325a86ac28b97755e55