### PR TITLE
Add partial opcode implementations

### DIFF
--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -39,16 +39,72 @@ int8_t cpu_step(cpu_t *cpu, mem_t *m)
     switch (opcode)
     {
         case 0x00:
-            cycles = nop(cpu);                       
+            cycles = nop(cpu);
             break;
         case 0x01:
             cycles = op_ld_bc_d16(cpu, m);
             break;
+        case 0x02:
+            cycles = op_ld_bc_a(cpu, m);
+            break;
         case 0x03:
             cycles = op_inc_bc(cpu);
             break;
+        case 0x04:
+            cycles = op_inc_b(cpu);
+            break;
+        case 0x05:
+            cycles = op_dec_b(cpu);
+            break;
+        case 0x06:
+            cycles = op_ld_b_d8(cpu, m);
+            break;
+        case 0x08:
+            /* LD (a16), SP not implemented */
+            fprintf(stderr, "Opcode 08 not implemented\n");
+            return -1;
+        case 0x09:
+            cycles = op_add_hl_bc(cpu);
+            break;
+        case 0x0A:
+            cycles = op_ld_a_bc(cpu, m);
+            break;
+        case 0x0B:
+            cycles = op_dec_bc(cpu);
+            break;
+        case 0x0C:
+            cycles = op_inc_c(cpu);
+            break;
+        case 0x0D:
+            cycles = op_dec_c(cpu);
+            break;
+        case 0x0E:
+            cycles = op_ld_c_d8(cpu, m);
+            break;
+        case 0x0F:
+            /* RRCA not implemented */
+            fprintf(stderr, "Opcode 0F not implemented\n");
+            return -1;
         case 0x07:
             cycles = op_rlca(cpu);
+            break;
+        case 0x11:
+            cycles = op_ld_de_d16(cpu, m);
+            break;
+        case 0x12:
+            cycles = op_ld_de_a(cpu, m);
+            break;
+        case 0x13:
+            cycles = op_inc_de(cpu);
+            break;
+        case 0x19:
+            cycles = op_add_hl_de(cpu);
+            break;
+        case 0x1A:
+            cycles = op_ld_a_de(cpu, m);
+            break;
+        case 0x1B:
+            cycles = op_dec_de(cpu);
             break;
         case 0x18:
             cycles = op_jr_s8(cpu, m);

--- a/src/cpu/cpu_ops.h
+++ b/src/cpu/cpu_ops.h
@@ -221,6 +221,142 @@ static inline uint8_t op_ld_l_d8(cpu_t *cpu, mem_t *m) {
     return 2;
 }
 
+/* LD (BC), A (opcode 0x02) */
+static inline uint8_t op_ld_bc_a(cpu_t *cpu, mem_t *m) {
+    mem_write_byte(m, cpu->r.bc, cpu->r.a);
+    cpu->pc++;
+    return 1;
+}
+
+/* LD B, d8 (opcode 0x06) */
+static inline uint8_t op_ld_b_d8(cpu_t *cpu, mem_t *m) {
+    cpu->r.b = mem_read_byte(m, cpu->pc + 1);
+    cpu->pc += 2;
+    return 2;
+}
+
+/* INC B (opcode 0x04) */
+static inline uint8_t op_inc_b(cpu_t *cpu) {
+    uint8_t val = cpu->r.b + 1;
+    cpu_set_flag(&cpu->r, F_Z, val == 0);
+    cpu_set_flag(&cpu->r, F_N, 0);
+    cpu_set_flag(&cpu->r, F_H, (cpu->r.b & 0x0F) + 1 > 0x0F);
+    cpu->r.b = val;
+    cpu->pc++;
+    return 1;
+}
+
+/* DEC B (opcode 0x05) */
+static inline uint8_t op_dec_b(cpu_t *cpu) {
+    uint8_t val = cpu->r.b - 1;
+    cpu_set_flag(&cpu->r, F_Z, val == 0);
+    cpu_set_flag(&cpu->r, F_N, 1);
+    cpu_set_flag(&cpu->r, F_H, (cpu->r.b & 0x0F) == 0);
+    cpu->r.b = val;
+    cpu->pc++;
+    return 1;
+}
+
+/* LD C, d8 (opcode 0x0E) */
+static inline uint8_t op_ld_c_d8(cpu_t *cpu, mem_t *m) {
+    cpu->r.c = mem_read_byte(m, cpu->pc + 1);
+    cpu->pc += 2;
+    return 2;
+}
+
+/* INC C (opcode 0x0C) */
+static inline uint8_t op_inc_c(cpu_t *cpu) {
+    uint8_t val = cpu->r.c + 1;
+    cpu_set_flag(&cpu->r, F_Z, val == 0);
+    cpu_set_flag(&cpu->r, F_N, 0);
+    cpu_set_flag(&cpu->r, F_H, (cpu->r.c & 0x0F) + 1 > 0x0F);
+    cpu->r.c = val;
+    cpu->pc++;
+    return 1;
+}
+
+/* DEC C (opcode 0x0D) */
+static inline uint8_t op_dec_c(cpu_t *cpu) {
+    uint8_t val = cpu->r.c - 1;
+    cpu_set_flag(&cpu->r, F_Z, val == 0);
+    cpu_set_flag(&cpu->r, F_N, 1);
+    cpu_set_flag(&cpu->r, F_H, (cpu->r.c & 0x0F) == 0);
+    cpu->r.c = val;
+    cpu->pc++;
+    return 1;
+}
+
+/* LD DE, d16 (opcode 0x11) */
+static inline uint8_t op_ld_de_d16(cpu_t *cpu, mem_t *m) {
+    cpu->r.de = mem_read_word(m, cpu->pc + 1);
+    cpu->pc += 3;
+    return 3;
+}
+
+/* LD (DE), A (opcode 0x12) */
+static inline uint8_t op_ld_de_a(cpu_t *cpu, mem_t *m) {
+    mem_write_byte(m, cpu->r.de, cpu->r.a);
+    cpu->pc++;
+    return 1;
+}
+
+/* INC DE (opcode 0x13) */
+static inline uint8_t op_inc_de(cpu_t *cpu) {
+    cpu->r.de++;
+    cpu->pc++;
+    return 2;
+}
+
+/* ADD HL, BC (opcode 0x09) */
+static inline uint8_t op_add_hl_bc(cpu_t *cpu) {
+    uint32_t res = cpu->r.hl + cpu->r.bc;
+    cpu_set_flag(&cpu->r, F_N, 0);
+    cpu_set_flag(&cpu->r, F_H, ((cpu->r.hl & 0x0FFF) + (cpu->r.bc & 0x0FFF)) > 0x0FFF);
+    cpu_set_flag(&cpu->r, F_C, res > 0xFFFF);
+    cpu->r.hl = (uint16_t)res;
+    cpu->pc++;
+    return 2;
+}
+
+/* ADD HL, DE (opcode 0x19) */
+static inline uint8_t op_add_hl_de(cpu_t *cpu) {
+    uint32_t res = cpu->r.hl + cpu->r.de;
+    cpu_set_flag(&cpu->r, F_N, 0);
+    cpu_set_flag(&cpu->r, F_H, ((cpu->r.hl & 0x0FFF) + (cpu->r.de & 0x0FFF)) > 0x0FFF);
+    cpu_set_flag(&cpu->r, F_C, res > 0xFFFF);
+    cpu->r.hl = (uint16_t)res;
+    cpu->pc++;
+    return 2;
+}
+
+/* LD A, (BC) (opcode 0x0A) */
+static inline uint8_t op_ld_a_bc(cpu_t *cpu, mem_t *m) {
+    cpu->r.a = mem_read_byte(m, cpu->r.bc);
+    cpu->pc++;
+    return 2;
+}
+
+/* LD A, (DE) (opcode 0x1A) */
+static inline uint8_t op_ld_a_de(cpu_t *cpu, mem_t *m) {
+    cpu->r.a = mem_read_byte(m, cpu->r.de);
+    cpu->pc++;
+    return 2;
+}
+
+/* DEC BC (opcode 0x0B) */
+static inline uint8_t op_dec_bc(cpu_t *cpu) {
+    cpu->r.bc--;
+    cpu->pc++;
+    return 2;
+}
+
+/* DEC DE (opcode 0x1B) */
+static inline uint8_t op_dec_de(cpu_t *cpu) {
+    cpu->r.de--;
+    cpu->pc++;
+    return 2;
+}
+
 
 
 


### PR DESCRIPTION
## Summary
- implement a number of previously missing CPU opcodes
- hook the new operations up in the opcode switch

## Testing
- `g++ -c src/cpu/cpu.cpp -Isrc -Isrc/cpu -Isrc/mem -Isrc/rom`
- `g++ -c -xc++ src/cpu/cpu_ops.h -Isrc -Isrc/cpu -Isrc/mem -Isrc/rom`


------
https://chatgpt.com/codex/tasks/task_e_684de093bda08325abcc5e4a1c808650