### PR TITLE
Implement two missing opcodes

### DIFF
--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -60,9 +60,8 @@ int8_t cpu_step(cpu_t *cpu, mem_t *m)
             cycles = op_ld_b_d8(cpu, m);
             break;
         case 0x08:
-            /* LD (a16), SP not implemented */
-            fprintf(stderr, "Opcode 08 not implemented\n");
-            return -1;
+            cycles = op_ld_a16_sp(cpu, m);
+            break;
         case 0x09:
             cycles = op_add_hl_bc(cpu);
             break;
@@ -82,9 +81,8 @@ int8_t cpu_step(cpu_t *cpu, mem_t *m)
             cycles = op_ld_c_d8(cpu, m);
             break;
         case 0x0F:
-            /* RRCA not implemented */
-            fprintf(stderr, "Opcode 0F not implemented\n");
-            return -1;
+            cycles = op_rrca(cpu);
+            break;
         case 0x07:
             cycles = op_rlca(cpu);
             break;
@@ -156,6 +154,7 @@ int8_t cpu_step(cpu_t *cpu, mem_t *m)
             break;
         case 0xE6:
             cycles = op_and_d8(cpu, m);
+            break;
         case 0xEA:
             cycles = op_ld_a16_a(cpu, m);
             break;

--- a/src/cpu/cpu_ops.h
+++ b/src/cpu/cpu_ops.h
@@ -66,7 +66,7 @@ static inline uint8_t op_jp_a16(cpu_t *cpu, mem_t *m){
 }
 
 /* RLCA (opcode 0x07)*/
-static inline uint8_t op_rlca(cpu_t *cpu){  
+static inline uint8_t op_rlca(cpu_t *cpu){
     uint8_t a = cpu->r.a;
     uint8_t carry = (a >> 7) & 0x01;
 
@@ -78,6 +78,21 @@ static inline uint8_t op_rlca(cpu_t *cpu){
     cpu_set_flag(&cpu->r, F_C, carry);
     cpu->pc++;
     return 1;  
+}
+
+/* RRCA (opcode 0x0F) */
+static inline uint8_t op_rrca(cpu_t *cpu){
+    uint8_t a = cpu->r.a;
+    uint8_t carry = a & 0x01;
+
+    cpu->r.a = (a >> 1) | (carry << 7);
+
+    cpu_set_flag(&cpu->r, F_Z, 0); // RRCA always resets Z
+    cpu_set_flag(&cpu->r, F_N, 0);
+    cpu_set_flag(&cpu->r, F_H, 0);
+    cpu_set_flag(&cpu->r, F_C, carry);
+    cpu->pc++;
+    return 1;
 }
 
 /* INC BC (opcode 0x03)*/
@@ -127,6 +142,14 @@ static inline uint8_t op_jr_nz_s8(cpu_t *cpu, mem_t *m) {
 
     cpu->pc += 2;
     return 2;
+}
+
+/* LD (a16), SP (opcode 0x08) */
+static inline uint8_t op_ld_a16_sp(cpu_t *cpu, mem_t *m){
+    uint16_t addr = mem_read_word(m, cpu->pc + 1);
+    mem_write_word(m, addr, cpu->sp);
+    cpu->pc += 3;
+    return 5;
 }
 
 /* LD (a16), A  (opcode 0xEA)*/


### PR DESCRIPTION
## Summary
- implement `LD (a16),SP` and `RRCA`
- wire new helpers into CPU switch
- fix missing `break` after `AND d8`

## Testing
- `cmake ..` *(fails: unable to download googletest)*

------
https://chatgpt.com/codex/tasks/task_e_684de2694e408325aec8731b46c1dde9