### PR TITLE
Add more CPU opcodes

### DIFF
--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -80,6 +80,15 @@ int8_t cpu_step(cpu_t *cpu, mem_t *m)
         case 0x0E:
             cycles = op_ld_c_d8(cpu, m);
             break;
+        case 0x14:
+            cycles = op_inc_d(cpu);
+            break;
+        case 0x15:
+            cycles = op_dec_d(cpu);
+            break;
+        case 0x16:
+            cycles = op_ld_d_d8(cpu, m);
+            break;
         case 0x0F:
             cycles = op_rrca(cpu);
             break;
@@ -104,6 +113,15 @@ int8_t cpu_step(cpu_t *cpu, mem_t *m)
         case 0x1B:
             cycles = op_dec_de(cpu);
             break;
+        case 0x1C:
+            cycles = op_inc_e(cpu);
+            break;
+        case 0x1D:
+            cycles = op_dec_e(cpu);
+            break;
+        case 0x1E:
+            cycles = op_ld_e_d8(cpu, m);
+            break;
         case 0x18:
             cycles = op_jr_s8(cpu, m);
             break;
@@ -113,11 +131,26 @@ int8_t cpu_step(cpu_t *cpu, mem_t *m)
         case 0x21:
             cycles = op_ld_hl_d16(cpu, m);
             break;
+        case 0x24:
+            cycles = op_inc_h(cpu);
+            break;
+        case 0x25:
+            cycles = op_dec_h(cpu);
+            break;
+        case 0x26:
+            cycles = op_ld_h_d8(cpu, m);
+            break;
         case 0x28:
             cycles = op_jp_z_s8(cpu, m);
             break;
         case 0x2E:
             cycles = op_ld_l_d8(cpu, m);
+            break;
+        case 0x2C:
+            cycles = op_inc_l(cpu);
+            break;
+        case 0x2D:
+            cycles = op_dec_l(cpu);
             break;
         case 0x40:
             cycles = op_ld_b_b(cpu, m);
@@ -125,11 +158,35 @@ int8_t cpu_step(cpu_t *cpu, mem_t *m)
         case 0x41:
             cycles = op_ld_b_c(cpu, m);
             break;
+        case 0x42:
+            cycles = op_ld_b_d(cpu);
+            break;
+        case 0x43:
+            cycles = op_ld_b_e(cpu);
+            break;
+        case 0x44:
+            cycles = op_ld_b_h(cpu);
+            break;
+        case 0x45:
+            cycles = op_ld_b_l(cpu);
+            break;
+        case 0x46:
+            cycles = op_ld_b_hl(cpu, m);
+            break;
+        case 0x47:
+            cycles = op_ld_b_a(cpu);
+            break;
         case 0x3E:
             cycles = op_ld_a_d8(cpu, m);
             break;
         case 0x77:
             cycles = op_ld_hl_a(cpu, m);
+            break;
+        case 0x7E:
+            cycles = op_ld_a_hl(cpu, m);
+            break;
+        case 0x4F:
+            cycles = op_ld_c_a(cpu);
             break;
         case 0x78:
             cycles = op_ld_a_b(cpu);

--- a/src/cpu/cpu_ops.h
+++ b/src/cpu/cpu_ops.h
@@ -228,6 +228,55 @@ static inline uint8_t op_ld_b_c(cpu_t *cpu, mem_t *m) {
     return 1;
 }
 
+/* LD B, D (opcode 0x42) */
+static inline uint8_t op_ld_b_d(cpu_t *cpu) {
+    cpu->r.b = cpu->r.d;
+    cpu->pc++;
+    return 1;
+}
+
+/* LD B, E (opcode 0x43) */
+static inline uint8_t op_ld_b_e(cpu_t *cpu) {
+    cpu->r.b = cpu->r.e;
+    cpu->pc++;
+    return 1;
+}
+
+/* LD B, H (opcode 0x44) */
+static inline uint8_t op_ld_b_h(cpu_t *cpu) {
+    cpu->r.b = cpu->r.h;
+    cpu->pc++;
+    return 1;
+}
+
+/* LD B, L (opcode 0x45) */
+static inline uint8_t op_ld_b_l(cpu_t *cpu) {
+    cpu->r.b = cpu->r.l;
+    cpu->pc++;
+    return 1;
+}
+
+/* LD B, (HL) (opcode 0x46) */
+static inline uint8_t op_ld_b_hl(cpu_t *cpu, mem_t *m) {
+    cpu->r.b = mem_read_byte(m, cpu->r.hl);
+    cpu->pc++;
+    return 2;
+}
+
+/* LD B, A (opcode 0x47) */
+static inline uint8_t op_ld_b_a(cpu_t *cpu) {
+    cpu->r.b = cpu->r.a;
+    cpu->pc++;
+    return 1;
+}
+
+/* LD C, A (opcode 0x4F) */
+static inline uint8_t op_ld_c_a(cpu_t *cpu) {
+    cpu->r.c = cpu->r.a;
+    cpu->pc++;
+    return 1;
+}
+
 /* LD B, B (opcode 0x40)*/
 static inline uint8_t op_ld_b_b(cpu_t *cpu, mem_t *m) {
     cpu->r.b = cpu->r.b;
@@ -244,6 +293,27 @@ static inline uint8_t op_ld_l_d8(cpu_t *cpu, mem_t *m) {
     return 2;
 }
 
+/* LD D, d8 (opcode 0x16) */
+static inline uint8_t op_ld_d_d8(cpu_t *cpu, mem_t *m) {
+    cpu->r.d = mem_read_byte(m, cpu->pc + 1);
+    cpu->pc += 2;
+    return 2;
+}
+
+/* LD E, d8 (opcode 0x1E) */
+static inline uint8_t op_ld_e_d8(cpu_t *cpu, mem_t *m) {
+    cpu->r.e = mem_read_byte(m, cpu->pc + 1);
+    cpu->pc += 2;
+    return 2;
+}
+
+/* LD H, d8 (opcode 0x26) */
+static inline uint8_t op_ld_h_d8(cpu_t *cpu, mem_t *m) {
+    cpu->r.h = mem_read_byte(m, cpu->pc + 1);
+    cpu->pc += 2;
+    return 2;
+}
+
 /* LD (BC), A (opcode 0x02) */
 static inline uint8_t op_ld_bc_a(cpu_t *cpu, mem_t *m) {
     mem_write_byte(m, cpu->r.bc, cpu->r.a);
@@ -256,6 +326,94 @@ static inline uint8_t op_ld_b_d8(cpu_t *cpu, mem_t *m) {
     cpu->r.b = mem_read_byte(m, cpu->pc + 1);
     cpu->pc += 2;
     return 2;
+}
+
+/* INC D (opcode 0x14) */
+static inline uint8_t op_inc_d(cpu_t *cpu) {
+    uint8_t val = cpu->r.d + 1;
+    cpu_set_flag(&cpu->r, F_Z, val == 0);
+    cpu_set_flag(&cpu->r, F_N, 0);
+    cpu_set_flag(&cpu->r, F_H, (cpu->r.d & 0x0F) + 1 > 0x0F);
+    cpu->r.d = val;
+    cpu->pc++;
+    return 1;
+}
+
+/* DEC D (opcode 0x15) */
+static inline uint8_t op_dec_d(cpu_t *cpu) {
+    uint8_t val = cpu->r.d - 1;
+    cpu_set_flag(&cpu->r, F_Z, val == 0);
+    cpu_set_flag(&cpu->r, F_N, 1);
+    cpu_set_flag(&cpu->r, F_H, (cpu->r.d & 0x0F) == 0);
+    cpu->r.d = val;
+    cpu->pc++;
+    return 1;
+}
+
+/* INC E (opcode 0x1C) */
+static inline uint8_t op_inc_e(cpu_t *cpu) {
+    uint8_t val = cpu->r.e + 1;
+    cpu_set_flag(&cpu->r, F_Z, val == 0);
+    cpu_set_flag(&cpu->r, F_N, 0);
+    cpu_set_flag(&cpu->r, F_H, (cpu->r.e & 0x0F) + 1 > 0x0F);
+    cpu->r.e = val;
+    cpu->pc++;
+    return 1;
+}
+
+/* DEC E (opcode 0x1D) */
+static inline uint8_t op_dec_e(cpu_t *cpu) {
+    uint8_t val = cpu->r.e - 1;
+    cpu_set_flag(&cpu->r, F_Z, val == 0);
+    cpu_set_flag(&cpu->r, F_N, 1);
+    cpu_set_flag(&cpu->r, F_H, (cpu->r.e & 0x0F) == 0);
+    cpu->r.e = val;
+    cpu->pc++;
+    return 1;
+}
+
+/* INC H (opcode 0x24) */
+static inline uint8_t op_inc_h(cpu_t *cpu) {
+    uint8_t val = cpu->r.h + 1;
+    cpu_set_flag(&cpu->r, F_Z, val == 0);
+    cpu_set_flag(&cpu->r, F_N, 0);
+    cpu_set_flag(&cpu->r, F_H, (cpu->r.h & 0x0F) + 1 > 0x0F);
+    cpu->r.h = val;
+    cpu->pc++;
+    return 1;
+}
+
+/* DEC H (opcode 0x25) */
+static inline uint8_t op_dec_h(cpu_t *cpu) {
+    uint8_t val = cpu->r.h - 1;
+    cpu_set_flag(&cpu->r, F_Z, val == 0);
+    cpu_set_flag(&cpu->r, F_N, 1);
+    cpu_set_flag(&cpu->r, F_H, (cpu->r.h & 0x0F) == 0);
+    cpu->r.h = val;
+    cpu->pc++;
+    return 1;
+}
+
+/* INC L (opcode 0x2C) */
+static inline uint8_t op_inc_l(cpu_t *cpu) {
+    uint8_t val = cpu->r.l + 1;
+    cpu_set_flag(&cpu->r, F_Z, val == 0);
+    cpu_set_flag(&cpu->r, F_N, 0);
+    cpu_set_flag(&cpu->r, F_H, (cpu->r.l & 0x0F) + 1 > 0x0F);
+    cpu->r.l = val;
+    cpu->pc++;
+    return 1;
+}
+
+/* DEC L (opcode 0x2D) */
+static inline uint8_t op_dec_l(cpu_t *cpu) {
+    uint8_t val = cpu->r.l - 1;
+    cpu_set_flag(&cpu->r, F_Z, val == 0);
+    cpu_set_flag(&cpu->r, F_N, 1);
+    cpu_set_flag(&cpu->r, F_H, (cpu->r.l & 0x0F) == 0);
+    cpu->r.l = val;
+    cpu->pc++;
+    return 1;
 }
 
 /* INC B (opcode 0x04) */
@@ -362,6 +520,13 @@ static inline uint8_t op_ld_a_bc(cpu_t *cpu, mem_t *m) {
 /* LD A, (DE) (opcode 0x1A) */
 static inline uint8_t op_ld_a_de(cpu_t *cpu, mem_t *m) {
     cpu->r.a = mem_read_byte(m, cpu->r.de);
+    cpu->pc++;
+    return 2;
+}
+
+/* LD A, (HL) (opcode 0x7E) */
+static inline uint8_t op_ld_a_hl(cpu_t *cpu, mem_t *m) {
+    cpu->r.a = mem_read_byte(m, cpu->r.hl);
     cpu->pc++;
     return 2;
 }

--- a/tests/cpu/cpu-test.cpp
+++ b/tests/cpu/cpu-test.cpp
@@ -135,3 +135,42 @@ TEST(cpu_step_vram_unlocked_success, cpu_step)
         }
     }
 }
+
+TEST(cpu_step_ld_d_opcodes, cpu_step)
+{
+    uint8_t rom_image[ROM_SIZE] = {};
+    cpu_t cpu = {};
+
+    cpu_reset(&cpu);
+    rom_image[cpu.pc] = 0x16;   // LD D, d8
+    rom_image[cpu.pc + 1] = 0x10;
+    rom_image[cpu.pc + 2] = 0x14; // INC D
+    rom_image[cpu.pc + 3] = 0x15; // DEC D
+
+    mem_t *mem = mem_create(rom_image, ROM_SIZE);
+
+    EXPECT_EQ(cpu_step(&cpu, mem), 0);
+    EXPECT_EQ(cpu.r.d, 0x10);
+
+    EXPECT_EQ(cpu_step(&cpu, mem), 0);
+    EXPECT_EQ(cpu.r.d, 0x11);
+
+    EXPECT_EQ(cpu_step(&cpu, mem), 0);
+    EXPECT_EQ(cpu.r.d, 0x10);
+}
+
+TEST(cpu_step_ld_a_hl, cpu_step)
+{
+    uint8_t rom_image[ROM_SIZE] = {};
+    cpu_t cpu = {};
+
+    cpu_reset(&cpu);
+    rom_image[cpu.pc] = 0x7E; // LD A, (HL)
+
+    mem_t *mem = mem_create(rom_image, ROM_SIZE);
+    cpu.r.hl = 0xC000;
+    mem_write_byte(mem, 0xC000, 0x55);
+
+    EXPECT_EQ(cpu_step(&cpu, mem), 0);
+    EXPECT_EQ(cpu.r.a, 0x55);
+}


### PR DESCRIPTION
## Summary
- expand CPU operations to handle more LD/INC/DEC instructions
- wire new opcodes into cpu_step
- cover new behaviour with unit tests

## Testing
- `cmake -S . -B build` *(fails: cannot download googletest)*

------
https://chatgpt.com/codex/tasks/task_e_684de4692e2c8325bac3a7943f322b24