### PR TITLE
Implement additional CPU opcodes

### DIFF
--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -353,6 +353,111 @@ int8_t cpu_step(cpu_t *cpu, mem_t *m)
         case 0x7F:
             cycles = op_ld_a_a(cpu);
             break;
+        case 0x80:
+            cycles = op_add_a_b(cpu);
+            break;
+        case 0x81:
+            cycles = op_add_a_c(cpu);
+            break;
+        case 0x82:
+            cycles = op_add_a_d(cpu);
+            break;
+        case 0x83:
+            cycles = op_add_a_e(cpu);
+            break;
+        case 0x84:
+            cycles = op_add_a_h(cpu);
+            break;
+        case 0x85:
+            cycles = op_add_a_l(cpu);
+            break;
+        case 0x86:
+            cycles = op_add_a_hl(cpu, m);
+            break;
+        case 0x87:
+            cycles = op_add_a_a(cpu);
+            break;
+        case 0xC6:
+            cycles = op_add_a_d8(cpu, m);
+            break;
+        case 0x90:
+            cycles = op_sub_b(cpu);
+            break;
+        case 0x91:
+            cycles = op_sub_c(cpu);
+            break;
+        case 0x92:
+            cycles = op_sub_d(cpu);
+            break;
+        case 0x93:
+            cycles = op_sub_e(cpu);
+            break;
+        case 0x94:
+            cycles = op_sub_h(cpu);
+            break;
+        case 0x95:
+            cycles = op_sub_l(cpu);
+            break;
+        case 0x96:
+            cycles = op_sub_hl(cpu, m);
+            break;
+        case 0x97:
+            cycles = op_sub_a_a(cpu);
+            break;
+        case 0xD6:
+            cycles = op_sub_d8(cpu, m);
+            break;
+        case 0xA0:
+            cycles = op_and_b(cpu);
+            break;
+        case 0xA1:
+            cycles = op_and_c(cpu);
+            break;
+        case 0xA2:
+            cycles = op_and_d(cpu);
+            break;
+        case 0xA3:
+            cycles = op_and_e(cpu);
+            break;
+        case 0xA4:
+            cycles = op_and_h(cpu);
+            break;
+        case 0xA5:
+            cycles = op_and_l(cpu);
+            break;
+        case 0xA6:
+            cycles = op_and_hl(cpu, m);
+            break;
+        case 0xA7:
+            cycles = op_and_a_a(cpu);
+            break;
+        case 0xB0:
+            cycles = op_or_b(cpu);
+            break;
+        case 0xB1:
+            cycles = op_or_c(cpu);
+            break;
+        case 0xB2:
+            cycles = op_or_d(cpu);
+            break;
+        case 0xB3:
+            cycles = op_or_e(cpu);
+            break;
+        case 0xB4:
+            cycles = op_or_h(cpu);
+            break;
+        case 0xB5:
+            cycles = op_or_l(cpu);
+            break;
+        case 0xB6:
+            cycles = op_or_hl(cpu, m);
+            break;
+        case 0xB7:
+            cycles = op_or_a_a(cpu);
+            break;
+        case 0xF6:
+            cycles = op_or_d8(cpu, m);
+            break;
         case 0xC2:
             cycles = op_jp_nz_a16(cpu, m);
             break;

--- a/src/cpu/cpu_ops.h
+++ b/src/cpu/cpu_ops.h
@@ -932,6 +932,296 @@ static inline uint8_t op_ld_a_a(cpu_t *cpu) {
     return 1;
 }
 
+/* Helper for 8-bit ADD operations */
+static inline void op_add_a(cpu_t *cpu, uint8_t value)
+{
+    uint16_t res = cpu->r.a + value;
+    cpu_set_flag(&cpu->r, F_Z, (res & 0xFF) == 0);
+    cpu_set_flag(&cpu->r, F_N, 0);
+    cpu_set_flag(&cpu->r, F_H, ((cpu->r.a & 0x0F) + (value & 0x0F)) > 0x0F);
+    cpu_set_flag(&cpu->r, F_C, res > 0xFF);
+    cpu->r.a = (uint8_t)res;
+}
+
+/* Helper for 8-bit SUB operations */
+static inline void op_sub_a(cpu_t *cpu, uint8_t value)
+{
+    uint16_t res = cpu->r.a - value;
+    cpu_set_flag(&cpu->r, F_Z, (res & 0xFF) == 0);
+    cpu_set_flag(&cpu->r, F_N, 1);
+    cpu_set_flag(&cpu->r, F_H, (cpu->r.a & 0x0F) < (value & 0x0F));
+    cpu_set_flag(&cpu->r, F_C, cpu->r.a < value);
+    cpu->r.a = (uint8_t)res;
+}
+
+/* Helper for 8-bit AND operations */
+static inline void op_and_a(cpu_t *cpu, uint8_t value)
+{
+    cpu->r.a &= value;
+    cpu_set_flag(&cpu->r, F_Z, cpu->r.a == 0);
+    cpu_set_flag(&cpu->r, F_N, 0);
+    cpu_set_flag(&cpu->r, F_H, 1);
+    cpu_set_flag(&cpu->r, F_C, 0);
+}
+
+/* Helper for 8-bit OR operations */
+static inline void op_or_a(cpu_t *cpu, uint8_t value)
+{
+    cpu->r.a |= value;
+    cpu_set_flag(&cpu->r, F_Z, cpu->r.a == 0);
+    cpu_set_flag(&cpu->r, F_N, 0);
+    cpu_set_flag(&cpu->r, F_H, 0);
+    cpu_set_flag(&cpu->r, F_C, 0);
+}
+
+/* ADD A, B (opcode 0x80) */
+static inline uint8_t op_add_a_b(cpu_t *cpu) {
+    op_add_a(cpu, cpu->r.b);
+    cpu->pc++;
+    return 1;
+}
+
+/* ADD A, C (opcode 0x81) */
+static inline uint8_t op_add_a_c(cpu_t *cpu) {
+    op_add_a(cpu, cpu->r.c);
+    cpu->pc++;
+    return 1;
+}
+
+/* ADD A, D (opcode 0x82) */
+static inline uint8_t op_add_a_d(cpu_t *cpu) {
+    op_add_a(cpu, cpu->r.d);
+    cpu->pc++;
+    return 1;
+}
+
+/* ADD A, E (opcode 0x83) */
+static inline uint8_t op_add_a_e(cpu_t *cpu) {
+    op_add_a(cpu, cpu->r.e);
+    cpu->pc++;
+    return 1;
+}
+
+/* ADD A, H (opcode 0x84) */
+static inline uint8_t op_add_a_h(cpu_t *cpu) {
+    op_add_a(cpu, cpu->r.h);
+    cpu->pc++;
+    return 1;
+}
+
+/* ADD A, L (opcode 0x85) */
+static inline uint8_t op_add_a_l(cpu_t *cpu) {
+    op_add_a(cpu, cpu->r.l);
+    cpu->pc++;
+    return 1;
+}
+
+/* ADD A, (HL) (opcode 0x86) */
+static inline uint8_t op_add_a_hl(cpu_t *cpu, mem_t *m) {
+    op_add_a(cpu, mem_read_byte(m, cpu->r.hl));
+    cpu->pc++;
+    return 2;
+}
+
+/* ADD A, A (opcode 0x87) */
+static inline uint8_t op_add_a_a(cpu_t *cpu) {
+    op_add_a(cpu, cpu->r.a);
+    cpu->pc++;
+    return 1;
+}
+
+/* ADD A, d8 (opcode 0xC6) */
+static inline uint8_t op_add_a_d8(cpu_t *cpu, mem_t *m) {
+    uint8_t d8 = mem_read_byte(m, cpu->pc + 1);
+    op_add_a(cpu, d8);
+    cpu->pc += 2;
+    return 2;
+}
+
+/* SUB B (opcode 0x90) */
+static inline uint8_t op_sub_b(cpu_t *cpu) {
+    op_sub_a(cpu, cpu->r.b);
+    cpu->pc++;
+    return 1;
+}
+
+/* SUB C (opcode 0x91) */
+static inline uint8_t op_sub_c(cpu_t *cpu) {
+    op_sub_a(cpu, cpu->r.c);
+    cpu->pc++;
+    return 1;
+}
+
+/* SUB D (opcode 0x92) */
+static inline uint8_t op_sub_d(cpu_t *cpu) {
+    op_sub_a(cpu, cpu->r.d);
+    cpu->pc++;
+    return 1;
+}
+
+/* SUB E (opcode 0x93) */
+static inline uint8_t op_sub_e(cpu_t *cpu) {
+    op_sub_a(cpu, cpu->r.e);
+    cpu->pc++;
+    return 1;
+}
+
+/* SUB H (opcode 0x94) */
+static inline uint8_t op_sub_h(cpu_t *cpu) {
+    op_sub_a(cpu, cpu->r.h);
+    cpu->pc++;
+    return 1;
+}
+
+/* SUB L (opcode 0x95) */
+static inline uint8_t op_sub_l(cpu_t *cpu) {
+    op_sub_a(cpu, cpu->r.l);
+    cpu->pc++;
+    return 1;
+}
+
+/* SUB (HL) (opcode 0x96) */
+static inline uint8_t op_sub_hl(cpu_t *cpu, mem_t *m) {
+    op_sub_a(cpu, mem_read_byte(m, cpu->r.hl));
+    cpu->pc++;
+    return 2;
+}
+
+/* SUB A (opcode 0x97) */
+static inline uint8_t op_sub_a_a(cpu_t *cpu) {
+    op_sub_a(cpu, cpu->r.a);
+    cpu->pc++;
+    return 1;
+}
+
+/* SUB d8 (opcode 0xD6) */
+static inline uint8_t op_sub_d8(cpu_t *cpu, mem_t *m) {
+    uint8_t d8 = mem_read_byte(m, cpu->pc + 1);
+    op_sub_a(cpu, d8);
+    cpu->pc += 2;
+    return 2;
+}
+
+/* AND B (opcode 0xA0) */
+static inline uint8_t op_and_b(cpu_t *cpu) {
+    op_and_a(cpu, cpu->r.b);
+    cpu->pc++;
+    return 1;
+}
+
+/* AND C (opcode 0xA1) */
+static inline uint8_t op_and_c(cpu_t *cpu) {
+    op_and_a(cpu, cpu->r.c);
+    cpu->pc++;
+    return 1;
+}
+
+/* AND D (opcode 0xA2) */
+static inline uint8_t op_and_d(cpu_t *cpu) {
+    op_and_a(cpu, cpu->r.d);
+    cpu->pc++;
+    return 1;
+}
+
+/* AND E (opcode 0xA3) */
+static inline uint8_t op_and_e(cpu_t *cpu) {
+    op_and_a(cpu, cpu->r.e);
+    cpu->pc++;
+    return 1;
+}
+
+/* AND H (opcode 0xA4) */
+static inline uint8_t op_and_h(cpu_t *cpu) {
+    op_and_a(cpu, cpu->r.h);
+    cpu->pc++;
+    return 1;
+}
+
+/* AND L (opcode 0xA5) */
+static inline uint8_t op_and_l(cpu_t *cpu) {
+    op_and_a(cpu, cpu->r.l);
+    cpu->pc++;
+    return 1;
+}
+
+/* AND (HL) (opcode 0xA6) */
+static inline uint8_t op_and_hl(cpu_t *cpu, mem_t *m) {
+    op_and_a(cpu, mem_read_byte(m, cpu->r.hl));
+    cpu->pc++;
+    return 2;
+}
+
+/* AND A (opcode 0xA7) */
+static inline uint8_t op_and_a_a(cpu_t *cpu) {
+    op_and_a(cpu, cpu->r.a);
+    cpu->pc++;
+    return 1;
+}
+
+/* OR B (opcode 0xB0) */
+static inline uint8_t op_or_b(cpu_t *cpu) {
+    op_or_a(cpu, cpu->r.b);
+    cpu->pc++;
+    return 1;
+}
+
+/* OR C (opcode 0xB1) */
+static inline uint8_t op_or_c(cpu_t *cpu) {
+    op_or_a(cpu, cpu->r.c);
+    cpu->pc++;
+    return 1;
+}
+
+/* OR D (opcode 0xB2) */
+static inline uint8_t op_or_d(cpu_t *cpu) {
+    op_or_a(cpu, cpu->r.d);
+    cpu->pc++;
+    return 1;
+}
+
+/* OR E (opcode 0xB3) */
+static inline uint8_t op_or_e(cpu_t *cpu) {
+    op_or_a(cpu, cpu->r.e);
+    cpu->pc++;
+    return 1;
+}
+
+/* OR H (opcode 0xB4) */
+static inline uint8_t op_or_h(cpu_t *cpu) {
+    op_or_a(cpu, cpu->r.h);
+    cpu->pc++;
+    return 1;
+}
+
+/* OR L (opcode 0xB5) */
+static inline uint8_t op_or_l(cpu_t *cpu) {
+    op_or_a(cpu, cpu->r.l);
+    cpu->pc++;
+    return 1;
+}
+
+/* OR (HL) (opcode 0xB6) */
+static inline uint8_t op_or_hl(cpu_t *cpu, mem_t *m) {
+    op_or_a(cpu, mem_read_byte(m, cpu->r.hl));
+    cpu->pc++;
+    return 2;
+}
+
+/* OR A (opcode 0xB7) */
+static inline uint8_t op_or_a_a(cpu_t *cpu) {
+    op_or_a(cpu, cpu->r.a);
+    cpu->pc++;
+    return 1;
+}
+
+/* OR d8 (opcode 0xF6) */
+static inline uint8_t op_or_d8(cpu_t *cpu, mem_t *m) {
+    uint8_t d8 = mem_read_byte(m, cpu->pc + 1);
+    op_or_a(cpu, d8);
+    cpu->pc += 2;
+    return 2;
+}
+
 
 
 

--- a/tests/cpu/cpu-test.cpp
+++ b/tests/cpu/cpu-test.cpp
@@ -234,3 +234,55 @@ TEST(cpu_step_hl_memory_ops, cpu_step)
     EXPECT_EQ(cpu_step(&cpu, mem), 0); // LD A, (HL)
     EXPECT_EQ(cpu.r.a, 0x10);
 }
+
+TEST(cpu_step_arithmetic_ops, cpu_step)
+{
+    uint8_t rom_image[ROM_SIZE] = {};
+    cpu_t cpu = {};
+
+    cpu_reset(&cpu);
+    rom_image[cpu.pc] = 0x06; // LD B, d8
+    rom_image[cpu.pc + 1] = 0x01;
+    rom_image[cpu.pc + 2] = 0x80; // ADD A, B
+    rom_image[cpu.pc + 3] = 0xC6; // ADD A, d8
+    rom_image[cpu.pc + 4] = 0x01;
+    rom_image[cpu.pc + 5] = 0x90; // SUB B
+    rom_image[cpu.pc + 6] = 0xD6; // SUB d8
+    rom_image[cpu.pc + 7] = 0x01;
+    rom_image[cpu.pc + 8] = 0xA0; // AND B
+    rom_image[cpu.pc + 9] = 0xE6; // AND d8
+    rom_image[cpu.pc + 10] = 0x0F;
+    rom_image[cpu.pc + 11] = 0xB0; // OR B
+    rom_image[cpu.pc + 12] = 0xF6; // OR d8
+    rom_image[cpu.pc + 13] = 0x02;
+
+    mem_t *mem = mem_create(rom_image, ROM_SIZE);
+
+    EXPECT_EQ(cpu_step(&cpu, mem), 0); // LD B, d8
+    EXPECT_EQ(cpu.r.b, 0x01);
+
+    EXPECT_EQ(cpu_step(&cpu, mem), 0); // ADD A, B
+    EXPECT_EQ(cpu.r.a, 0x01);
+
+    EXPECT_EQ(cpu_step(&cpu, mem), 0); // ADD A, d8
+    EXPECT_EQ(cpu.r.a, 0x02);
+
+    EXPECT_EQ(cpu_step(&cpu, mem), 0); // SUB B
+    EXPECT_EQ(cpu.r.a, 0x01);
+
+    EXPECT_EQ(cpu_step(&cpu, mem), 0); // SUB d8
+    EXPECT_EQ(cpu.r.a, 0x00);
+    EXPECT_TRUE(cpu_get_flag(&cpu.r, F_Z));
+
+    EXPECT_EQ(cpu_step(&cpu, mem), 0); // AND B
+    EXPECT_EQ(cpu.r.a, 0x00);
+
+    EXPECT_EQ(cpu_step(&cpu, mem), 0); // AND d8
+    EXPECT_EQ(cpu.r.a, 0x00);
+
+    EXPECT_EQ(cpu_step(&cpu, mem), 0); // OR B
+    EXPECT_EQ(cpu.r.a, 0x01);
+
+    EXPECT_EQ(cpu_step(&cpu, mem), 0); // OR d8
+    EXPECT_EQ(cpu.r.a, 0x03);
+}


### PR DESCRIPTION
## Summary
- extend opcode table to support ADD, SUB, AND and OR operations
- add helper routines for 8‑bit ALU operations
- update tests to cover new arithmetic instructions

## Testing
- `cmake -S . -B build` *(fails: unable to download googletest)*
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684de8845a8483259650f531ebccab56