### PR TITLE
Add DI opcode and expose individual tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,9 +62,29 @@ target_include_directories(tests PRIVATE
   tests/ctest)
 
 target_link_libraries(tests ${DISPLAY_LIBS})
-  
-# Register the tests
-add_test(NAME boyc_tests COMMAND tests)
+
+# Register the tests individually so IDEs can display each one
+set(BOYC_TESTS
+  cpu_dump_test_sueccess.cpu_dump
+  cpu_reset_test_success.cpu_reset
+  cpu_step_one_simple_step_success.cpu_step
+  cpu_step_write_x8000_success.cpu_step
+  cpu_step_oam_lock_success.cpu_step
+  cpu_step_vram_unlocked_success.cpu_step
+  cpu_step_ld_d_opcodes.cpu_step
+  cpu_step_ld_a_hl.cpu_step
+  cpu_step_additional_opcodes.cpu_step
+  cpu_step_hl_memory_ops.cpu_step
+  cpu_step_arithmetic_ops.cpu_step
+  cpu_step_sp_and_hl_inc_dec_ops.cpu_step
+  cpu_step_disable_interrupts.cpu_step
+  display_line_test.draw_line
+  display_circle_test.draw_circle
+)
+
+foreach(test_name ${BOYC_TESTS})
+  add_test(NAME ${test_name} COMMAND tests ${test_name})
+endforeach()
 
 # Get Test roms
 include(ExternalProject)

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -473,6 +473,9 @@ int8_t cpu_step(cpu_t *cpu, mem_t *m)
         case 0xF6:
             cycles = op_or_d8(cpu, m);
             break;
+        case 0xF3:
+            cycles = op_di(cpu);
+            break;
         case 0xC2:
             cycles = op_jp_nz_a16(cpu, m);
             break;

--- a/src/cpu/cpu_ops.h
+++ b/src/cpu/cpu_ops.h
@@ -1262,6 +1262,13 @@ static inline uint8_t op_or_d8(cpu_t *cpu, mem_t *m) {
     return 2;
 }
 
+/* DI (opcode 0xF3) */
+static inline uint8_t op_di(cpu_t *cpu) {
+    cpu->ime = 0;
+    cpu->pc++;
+    return 1;
+}
+
 
 
 

--- a/tests/cpu/cpu-test.cpp
+++ b/tests/cpu/cpu-test.cpp
@@ -323,3 +323,18 @@ TEST(cpu_step_sp_and_hl_inc_dec_ops, cpu_step)
     EXPECT_EQ(cpu.r.a, 0x66);
     EXPECT_EQ(cpu.r.hl, 0xC000);
 }
+
+TEST(cpu_step_disable_interrupts, cpu_step)
+{
+    uint8_t rom_image[ROM_SIZE] = {};
+    cpu_t cpu = {};
+
+    cpu_reset(&cpu);
+    cpu.ime = 1;
+    rom_image[cpu.pc] = 0xF3; // DI
+
+    mem_t *mem = mem_create(rom_image, ROM_SIZE);
+
+    EXPECT_EQ(cpu_step(&cpu, mem), 0);
+    EXPECT_EQ(cpu.ime, 0);
+}

--- a/tests/ctest/ctest.c
+++ b/tests/ctest/ctest.c
@@ -1,5 +1,6 @@
 #include "ctest.h"
 #include <stdlib.h>
+#include <string.h>
 
 #define MAX_TESTS 1024
 
@@ -33,4 +34,23 @@ int ctest_run_all(void) {
     }
     printf("[==========] %d tests ran. %d failed.\n", ctest_count, fails);
     return fails ? 1 : 0;
+}
+
+int ctest_run_by_name(const char *name) {
+    for (int i = 0; i < ctest_count; ++i) {
+        if (strcmp(ctest_cases[i].name, name) == 0) {
+            printf("[ RUN      ] %s\n", ctest_cases[i].name);
+            ctest_current_failed = 0;
+            ctest_cases[i].func();
+            if (ctest_current_failed) {
+                printf("[  FAILED  ] %s\n", ctest_cases[i].name);
+            } else {
+                printf("[       OK ] %s\n", ctest_cases[i].name);
+            }
+            printf("[==========] 1 tests ran. %d failed.\n", ctest_current_failed ? 1 : 0);
+            return ctest_current_failed ? 1 : 0;
+        }
+    }
+    fprintf(stderr, "Unknown test %s\n", name);
+    return 1;
 }

--- a/tests/ctest/ctest.h
+++ b/tests/ctest/ctest.h
@@ -11,6 +11,7 @@ typedef void (*ctest_func)(void);
 
 void ctest_register(const char *name, ctest_func func);
 int ctest_run_all(void);
+int ctest_run_by_name(const char *name);
 extern int ctest_current_failed;
 
 #define TEST(suite, name) \

--- a/tests/main.c
+++ b/tests/main.c
@@ -1,5 +1,8 @@
 #include "ctest.h"
 
-int main(void) {
+int main(int argc, char **argv) {
+    if (argc > 1) {
+        return ctest_run_by_name(argv[1]);
+    }
     return ctest_run_all();
 }


### PR DESCRIPTION
## Summary
- implement opcode 0xF3 (DI) in CPU
- extend tiny test framework to run a single test by name
- register every test separately with CTest
- add a unit test for DI

## Testing
- `cmake -S . -B build`
- `cmake --build build --target tests`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684df05380d88325832f1f66272f9675