### PR TITLE
Fix SDL renderer creation error

### DIFF
--- a/src/display/display.cpp
+++ b/src/display/display.cpp
@@ -26,9 +26,14 @@ int display_init(int width, int height)
     renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
     if (renderer == NULL) {
         fprintf(stderr, "SDL_CreateRenderer Error: %s\n", SDL_GetError());
-        SDL_DestroyWindow(window);
-        SDL_Quit();
-        return -1;
+        fprintf(stderr, "Falling back to software renderer\n");
+        renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_SOFTWARE);
+        if (renderer == NULL) {
+            fprintf(stderr, "SDL_CreateRenderer fallback Error: %s\n", SDL_GetError());
+            SDL_DestroyWindow(window);
+            SDL_Quit();
+            return -1;
+        }
     }
 
     texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_ARGB8888,


### PR DESCRIPTION
## Summary
- fallback to SDL software renderer if accelerated renderer creation fails

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684e932b89848325aa06f657d6920e66